### PR TITLE
Improve ECC key creation and fix minor inefficiency

### DIFF
--- a/tpm_test.go
+++ b/tpm_test.go
@@ -139,6 +139,9 @@ func TestECC(t *testing.T) {
 		}
 
 		pub := key.Public()
+		if got, want := pub.(*ecdsa.PublicKey).Curve.Params().BitSize, curve.Params().BitSize; got != want {
+			t.Fatalf("pub.Curve.Params().BitSize = %d, want %d", got, want)
+		}
 		hashed := sha256.Sum256([]byte(payload))
 		sig, err := key.Sign(nil, hashed[:], crypto.SHA256)
 		if err != nil {


### PR DESCRIPTION

### Description

Note: This change was generated with gemini code assist.

This commit addresses two issues:

1.  **Fix ECC key creation for larger curves:** Previously, the `createLocked` function in `tpm.go` used a fixed-size buffer for the `Unique` field during ECC key creation. This could lead to truncated X and Y coordinates for curves larger than P256 (e.g., P384, P521), although the TPM simulator appeared to silently pad these. The code now dynamically sizes this buffer based on the curve's bit size, ensuring that correctly sized coordinates are always sent to the TPM.

2.  **Remove redundant flushLocked() call:** The `UnmarshalKey()` function in `tpm.go` contained an unnecessary call to `flushLocked()` when unmarshaling an already loaded key. This has been removed for minor efficiency improvement.

Testing revealed that the TPM simulator's behavior of silently padding truncated input coordinates made more granular tests for public key coordinate lengths ineffective. Therefore, the `TestECC` remains focused on functional correctness via `ecdsa.VerifyASN1`, which is sufficient given the TPM's behavior.

### Type of change

* [ ] New feature
* [ ] Feature improvement
* [x] Bug fix
* [ ] Documentation
* [ ] Cleanup / refactoring
* [ ] Other (please explain)

### How is this change tested ?

* [x] Unit tests
* [ ] Manual tests (explain)
* [ ] Tests are not needed
